### PR TITLE
Add GitHub Actions workflow for Windows and Mac releases

### DIFF
--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -1,0 +1,71 @@
+name: Publish Release
+
+on:
+  push:
+    tags:
+      - 'v*'
+  workflow_dispatch:
+
+jobs:
+  build:
+    name: Build and Publish
+    runs-on: ${{ matrix.os }}
+    strategy:
+      matrix:
+        os: [windows-latest, macos-latest]
+        runtime: [win-x64, osx-x64, osx-arm64]
+        exclude:
+          - os: windows-latest
+            runtime: osx-x64
+          - os: windows-latest
+            runtime: osx-arm64
+          - os: macos-latest
+            runtime: win-x64
+
+    steps:
+    - name: Checkout
+      uses: actions/checkout@v4
+      with:
+        submodules: recursive
+
+    - name: Setup .NET
+      uses: actions/setup-dotnet@v4
+      with:
+        dotnet-version: 8.0.x
+
+    - name: Restore dependencies
+      run: dotnet restore CSharpCad6/CSharpCad6.csproj
+
+    - name: Publish
+      run: |
+        dotnet publish CSharpCad6/CSharpCad6.csproj -c Release -r ${{ matrix.runtime }} --self-contained true -p:PublishSingleFile=true -o ./publish/${{ matrix.runtime }}
+
+    - name: Zip Artifact
+      shell: bash
+      run: |
+        cd publish/${{ matrix.runtime }}
+        zip -r ../../CSharpCAD-${{ matrix.runtime }}.zip .
+
+    - name: Upload Artifact
+      uses: actions/upload-artifact@v4
+      with:
+        name: CSharpCAD-${{ matrix.runtime }}
+        path: CSharpCAD-${{ matrix.runtime }}.zip
+
+  release:
+    name: Create Release
+    needs: build
+    runs-on: ubuntu-latest
+    if: startsWith(github.ref, 'refs/tags/')
+    steps:
+    - name: Download Artifacts
+      uses: actions/download-artifact@v4
+      with:
+        path: ./artifacts
+
+    - name: Create Release
+      uses: softprops/action-gh-release@v1
+      with:
+        files: ./artifacts/**/*.zip
+      env:
+        GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/ApiTest/ApiTest.csproj
+++ b/ApiTest/ApiTest.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <OutputType>Exe</OutputType>
     <GenerateAssemblyInfo>false</GenerateAssemblyInfo>
   </PropertyGroup>
@@ -8,7 +8,7 @@
     <ProjectReference Include="..\Submodules\agg-sharp\agg\Agg.csproj" />
     <ProjectReference Include="..\Submodules\agg-sharp\clipper_library\clipper_library.csproj" />
     <ProjectReference Include="..\Submodules\agg-sharp\Csg\Csg.csproj" />
-    <ProjectReference Include="..\Submodules\agg-sharp\PlatformWin32\PlatformWin32.csproj" />
+    <ProjectReference Include="..\Submodules\agg-sharp\PlatformWin32\PlatformWin32.csproj" Condition="'$(OS)' == 'Windows_NT'" />
     <ProjectReference Include="..\Submodules\agg-sharp\PolygonMesh\PolygonMesh.csproj" />
     <ProjectReference Include="..\Submodules\agg-sharp\RenderOpenGl\RenderOpenGl.csproj" />
     <ProjectReference Include="..\Submodules\agg-sharp\Tesselate\Tesselate.csproj" />

--- a/CSharpCad.Test/CSharpCad.Test.csproj
+++ b/CSharpCad.Test/CSharpCad.Test.csproj
@@ -2,7 +2,7 @@
 
   <PropertyGroup>
     <OutputType>Exe</OutputType>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
   </PropertyGroup>
 
   <ItemGroup>

--- a/CSharpCad6/CSharpCad6.csproj
+++ b/CSharpCad6/CSharpCad6.csproj
@@ -1,6 +1,6 @@
 <Project Sdk="Microsoft.NET.Sdk">
   <PropertyGroup>
-    <TargetFramework>net8.0-windows</TargetFramework>
+    <TargetFramework>net8.0</TargetFramework>
     <Configuration Condition=" '$(Configuration)' == '' ">Release</Configuration>
     <OutputType>WinExe</OutputType>
     <GenerateBindingRedirectsOutputType>true</GenerateBindingRedirectsOutputType>
@@ -80,7 +80,7 @@
     <ProjectReference Include="..\Submodules\agg-sharp\agg\Agg.csproj" />
     <ProjectReference Include="..\Submodules\agg-sharp\Csg\Csg.csproj" />
     <ProjectReference Include="..\Submodules\agg-sharp\Gui\Gui.csproj" />
-    <ProjectReference Include="..\Submodules\agg-sharp\PlatformWin32\PlatformWin32.csproj" />
+    <ProjectReference Include="..\Submodules\agg-sharp\PlatformWin32\PlatformWin32.csproj" Condition="'$(OS)' == 'Windows_NT'" />
     <ProjectReference Include="..\Submodules\agg-sharp\Glfw\GlfwProvider.csproj" />
     <ProjectReference Include="..\Submodules\agg-sharp\PolygonMesh\PolygonMesh.csproj" />
     <ProjectReference Include="..\Submodules\agg-sharp\RenderOpenGl\RenderOpenGl.csproj" />

--- a/CSharpCad6/Program.cs
+++ b/CSharpCad6/Program.cs
@@ -1,5 +1,6 @@
 ﻿using MatterHackers.Agg.Platform;
 using System;
+using System.Runtime.InteropServices;
 using System.Globalization;
 using System.Threading;
 using System.IO;
@@ -12,7 +13,14 @@ class Program
     [STAThread]
     static void Main(string[] args)
     {
-        AggContext.Config.ProviderTypes.SystemWindowProvider = "MatterHackers.Agg.UI.OpenGLWinformsWindowProvider, agg_platform_win32";
+        if (RuntimeInformation.IsOSPlatform(OSPlatform.Windows))
+        {
+            AggContext.Config.ProviderTypes.SystemWindowProvider = "MatterHackers.Agg.UI.OpenGLWinformsWindowProvider, agg_platform_win32";
+        }
+        else
+        {
+            AggContext.Config.ProviderTypes.SystemWindowProvider = "MatterHackers.GlfwProvider.GlfwWindowProvider, MatterHackers.GlfwProvider";
+        }
 
         try
         {


### PR DESCRIPTION
Added a GitHub Actions workflow to publish releases for Windows and macOS. The workflow builds CSharpCad6 for win-x64, osx-x64, and osx-arm64, packages them as zip files, and uploads them to a GitHub release. Supporting changes were made to the project files and main entry point to ensure cross-platform compatibility.

---
*PR created automatically by Jules for task [2267251993978408117](https://jules.google.com/task/2267251993978408117) started by @roboter*