### PR TITLE
Fix robust logging and submodule issues for macOS

### DIFF
--- a/OpenSharpCAD/MainWindow.cs
+++ b/OpenSharpCAD/MainWindow.cs
@@ -213,13 +213,20 @@ namespace CSharpCAD
         }
         private void LogException(Exception ex)
         {
+            // Always output to console so the user can see what happened
+            Console.Error.WriteLine($"ERROR: {ex.Message}");
+            Console.Error.WriteLine(ex.StackTrace);
+
             try
             {
-                string logDir = Path.Combine(
-                    Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                    "CSharpCAD",
-                    "logs"
-                );
+                string baseDir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                if (string.IsNullOrEmpty(baseDir))
+                {
+                    baseDir = Path.GetTempPath();
+                }
+
+                string logDir = Path.Combine(baseDir, "CSharpCAD", "logs");
+
                 if (!Directory.Exists(logDir))
                 {
                     Directory.CreateDirectory(logDir);

--- a/OpenSharpCAD/Program.cs
+++ b/OpenSharpCAD/Program.cs
@@ -37,19 +37,32 @@ class Program
         }
         catch (Exception ex)
         {
-            string logDir = Path.Combine(
-                Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData),
-                "CSharpCAD",
-                "logs"
-            );
+            // Always output to console so the user can see what happened
+            Console.Error.WriteLine($"GLOBAL ERROR: {ex.Message}");
+            Console.Error.WriteLine(ex.StackTrace);
 
-            if (!Directory.Exists(logDir))
+            try
             {
-                Directory.CreateDirectory(logDir);
+                string baseDir = Environment.GetFolderPath(Environment.SpecialFolder.LocalApplicationData);
+                if (string.IsNullOrEmpty(baseDir))
+                {
+                    baseDir = Path.GetTempPath();
+                }
+
+                string logDir = Path.Combine(baseDir, "CSharpCAD", "logs");
+
+                if (!Directory.Exists(logDir))
+                {
+                    Directory.CreateDirectory(logDir);
+                }
+                string logPath = Path.Combine(logDir, "errors.log");
+                string logMessage = $"[{DateTime.Now}] GLOBAL ERROR: {ex.Message}{Environment.NewLine}{ex.StackTrace}{Environment.NewLine}{new string('=', 30)}{Environment.NewLine}";
+                File.AppendAllText(logPath, logMessage);
             }
-            string logPath = Path.Combine(logDir, "errors.log");
-            string logMessage = $"[{DateTime.Now}] GLOBAL ERROR: {ex.Message}{Environment.NewLine}{ex.StackTrace}{Environment.NewLine}{new string('=', 30)}{Environment.NewLine}";
-            File.AppendAllText(logPath, logMessage);
+            catch (Exception logEx)
+            {
+                Console.Error.WriteLine($"Failed to write to log file: {logEx.Message}");
+            }
         }
     }
 }


### PR DESCRIPTION
Fixed a runtime crash on macOS where the exception handler failed due to lack of permissions for the log directory. Also fixed build issues by updating submodules.

---
*PR created automatically by Jules for task [1252973002679239414](https://jules.google.com/task/1252973002679239414) started by @roboter*